### PR TITLE
Removed vkImageView for copy

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,7 +25,7 @@ android {
     defaultConfig {
         applicationId "dev.hadrosaur.vulkanphotobooth"
         minSdkVersion 27
-        targetSdkVersion 28
+        targetSdkVersion 30
         versionCode 52
         versionName "1.52"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -33,6 +33,7 @@ android {
             cmake {
                 cppFlags "-std=c++17"
                 abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'
+//                abiFilters 'arm64-v8a'
             }
         }
     }

--- a/app/src/main/cpp/vulkan-utils/VulkanSwapchain.cpp
+++ b/app/src/main/cpp/vulkan-utils/VulkanSwapchain.cpp
@@ -51,10 +51,6 @@ VulkanSwapchain::~VulkanSwapchain() {
             vkDestroyImageView(mInstance->device(), mSwapchainImages[i].imageView, nullptr);
             mSwapchainImages[i].imageView = VK_NULL_HANDLE;
         }
-        if (mSwapchainImages[i].imageViewCopy != VK_NULL_HANDLE) {
-            vkDestroyImageView(mInstance->device(), mSwapchainImages[i].imageViewCopy, nullptr);
-            mSwapchainImages[i].imageViewCopy = VK_NULL_HANDLE;
-        }
         if (mSwapchainImages[i].imageCopy != VK_NULL_HANDLE) {
             vkDestroyImage(mInstance->device(), mSwapchainImages[i].imageCopy, nullptr);
             mSwapchainImages[i].imageCopy = VK_NULL_HANDLE;
@@ -242,29 +238,6 @@ bool VulkanSwapchain::init(VkSurfaceKHR *vkSurface, VkSurfaceCapabilitiesKHR *su
         VK_CALL(vkAllocateMemory(mInstance->device(), &imageCopyAllocInfo, nullptr, &imageCopyMemory) != VK_SUCCESS);
         vkBindImageMemory(mInstance->device(), imageCopy, imageCopyMemory, 0);
 
-        VkImageView imageViewCopy;
-        VkImageViewCreateInfo imageViewCopyCreateInfo = {
-                .sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,
-                .image = imageCopy,
-                .pNext = nullptr,
-                .flags = 0u,
-                .viewType = VK_IMAGE_VIEW_TYPE_2D,
-                .format = VK_FORMAT_R8G8B8A8_UNORM,
-//                .format = VK_FORMAT_A8B8G8R8_UINT_PACK32,
-                .components = {VK_COMPONENT_SWIZZLE_IDENTITY,
-                               VK_COMPONENT_SWIZZLE_IDENTITY,
-                               VK_COMPONENT_SWIZZLE_IDENTITY,
-                               VK_COMPONENT_SWIZZLE_IDENTITY},
-                .subresourceRange = (VkImageSubresourceRange) {
-                        .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
-                        .baseMipLevel = 0,
-                        .levelCount = 1,
-                        .baseArrayLayer = 0,
-                        .layerCount = 1,
-                },
-        };
-        VK_CALL(vkCreateImageView(mInstance->device(), &imageViewCopyCreateInfo, nullptr, &imageViewCopy));
-
         VkSemaphore copySemaphore;
         VkSemaphoreCreateInfo copySemaphoreCreateInfo = {
                 .sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO,
@@ -391,7 +364,6 @@ bool VulkanSwapchain::init(VkSurfaceKHR *vkSurface, VkSurfaceCapabilitiesKHR *su
                 .imageFenceSet = false,
 
                 .imageCopy = imageCopy,
-                .imageViewCopy = imageViewCopy,
                 .imageCopyMemory = imageCopyMemory,
                 .copySemaphore = copySemaphore,
                 .imageCopyFence = imageCopyFence,

--- a/app/src/main/cpp/vulkan-utils/VulkanSwapchain.h
+++ b/app/src/main/cpp/vulkan-utils/VulkanSwapchain.h
@@ -37,7 +37,6 @@ struct SwapchainImage {
 
     // Framebuffer variables that will copied out to the ring_buffer to be saved
     VkImage imageCopy;
-    VkImageView imageViewCopy;
     VkDeviceMemory imageCopyMemory;
     VkSemaphore copySemaphore;
     VkFence imageCopyFence;

--- a/app/src/main/java/dev/hadrosaur/vulkanphotobooth/MainActivity.kt
+++ b/app/src/main/java/dev/hadrosaur/vulkanphotobooth/MainActivity.kt
@@ -53,6 +53,12 @@ import java.io.File
 import java.lang.Exception
 import java.lang.Thread.sleep
 import kotlin.concurrent.thread
+import android.content.pm.ConfigurationInfo
+
+import android.app.ActivityManager
+
+
+
 
 // Arbitrary ids to keep track of permission requests
 private const val REQUEST_CAMERA_PERMISSION = 1

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.0-alpha14'
+        classpath 'com.android.tools.build:gradle:7.0.0-rc01'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 //        classpath 'com.google.gms:google-services:4.3.3'
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-rc-1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip


### PR DESCRIPTION
There was an unnecessary vkImageView called imageViewCopy that
had been created for the vkImage that was being copied out to the
animated image file. This was unused and in violation of the spec
ase the imageView was designated for transfer only.