### PR TITLE
Optimized AHB creation

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,7 +21,7 @@ plugins {
 }
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 30
     defaultConfig {
         applicationId "dev.hadrosaur.vulkanphotobooth"
         minSdkVersion 27

--- a/app/src/main/cpp/ImageReaderListener.h
+++ b/app/src/main/cpp/ImageReaderListener.h
@@ -21,6 +21,7 @@
 #include <media/NdkImageReader.h>
 #include "vulkan-utils/VulkanImageRenderer.h"
 #include "ring_buffer.h"
+#include "vulkan-utils/VulkanAHBManager.h"
 
 /**
  * Listener for each new frame received from the camera
@@ -44,6 +45,7 @@ public:
     static int gif_frames_captured; // Counter for # frames captured for GIF so far
 
     ImageReaderListener(VulkanInstance *instance, VulkanImageRenderer *renderer, FilterParams *filterParams, ANativeWindow *outputWindow);
+    VulkanAHBManager vahb_manager;
 
     static void onImageAvailableCallback(void* obj, AImageReader* reader);
     void onImageAvailable(void* obj, AImageReader* reader);

--- a/app/src/main/cpp/vulkan-utils/CMakeLists.txt
+++ b/app/src/main/cpp/vulkan-utils/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library(vulkan-utils SHARED
         vulkan_utils.cpp
         VulkanInstance.cpp
         VulkanAHardwareBufferImage.cpp
+        VulkanAHBManager.cpp
         VulkanImageRenderer.cpp
         VulkanSwapchain.cpp
         VulkanSurface.cpp

--- a/app/src/main/cpp/vulkan-utils/VulkanAHBManager.cpp
+++ b/app/src/main/cpp/vulkan-utils/VulkanAHBManager.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "VulkanAHBManager.h"
+#include "vulkan_utils.h"
+
+VulkanAHBManager::~VulkanAHBManager() {
+    // Call destructor for all the created VulkanAHardwareBufferImages
+    for (auto item : ahb_map) {
+        item.second->~VulkanAHardwareBufferImage();
+    }
+}
+
+VulkanAHardwareBufferImage *VulkanAHBManager::getVulkanAHB(AHardwareBuffer *ahb) {
+    // Not available until SDK 31. Once available we should use the AHB's id, not its memory address
+    // uint64_t ahb_id;
+    // AHardwareBuffer_getId(ahb, &ahb_id);
+
+    // Fetch existing vahb from map or get a nullptr if not in the map
+    VulkanAHardwareBufferImage *vahb = ahb_map[ahb];
+
+    // If this is the first time seeing this ahb, set it up and add to map
+    if (nullptr == vahb) {
+        vahb = new VulkanAHardwareBufferImage(instance);
+        ASSERT_FORMATTED(vahb->init(ahb, true),
+                         "Could not init VulkanAHardwareBufferImage.");
+        ahb_map[ahb] = vahb;
+    }
+    return vahb;
+}
+
+void VulkanAHBManager::setVulkanInstance(VulkanInstance *pInstance) {
+    this->instance = pInstance;
+}

--- a/app/src/main/cpp/vulkan-utils/VulkanAHBManager.h
+++ b/app/src/main/cpp/vulkan-utils/VulkanAHBManager.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef VULKAN_PHOTO_BOOTH_VULKANAHBMANAGER_H
+#define VULKAN_PHOTO_BOOTH_VULKANAHBMANAGER_H
+
+#include <unordered_map>
+#include <media/NdkImageReader.h>
+#include "VulkanAHardwareBufferImage.h"
+
+/**
+ * Manager class for AHardwareBuffers (ahbs) / VulkanAHardwareBufferImages (vhbs)
+ *
+ * The ImageReader will only use a fixed number of ahbs. As these are seen, create a corresponding
+ * vahb and store it in a hashmap. This avoids needing to recreate and reinitalize vahbs every
+ * frame.
+ */
+class VulkanAHBManager {
+    public:
+        ~VulkanAHBManager();
+        /**
+         * If the AHardwareBuffer has already been added to the map, return the
+         * VulkanAHardwareBufferImage associated with it. Otherwise initialize a new
+         * VulkanAHardwareBufferImage, add it to the map, and return it.
+         *
+         * @return the VulkanAHardwareBufferImage associated with the given AHardwareBuffer
+         */
+        VulkanAHardwareBufferImage *getVulkanAHB(AHardwareBuffer *);
+        void setVulkanInstance(VulkanInstance *pInstance);
+
+    private:
+        // Hashmap indexed by pointers to AHBs
+        std::unordered_map<AHardwareBuffer *, VulkanAHardwareBufferImage *> ahb_map;
+        VulkanInstance *instance;
+};
+
+
+#endif //VULKAN_PHOTO_BOOTH_VULKANAHBMANAGER_H

--- a/app/src/main/cpp/vulkan-utils/VulkanAHardwareBufferImage.cpp
+++ b/app/src/main/cpp/vulkan-utils/VulkanAHardwareBufferImage.cpp
@@ -26,6 +26,9 @@ bool VulkanAHardwareBufferImage::init(AHardwareBuffer *buffer, bool useExternalF
     AHardwareBuffer_describe(buffer, &bufferDesc);
     ASSERT(bufferDesc.layers == 1);
 
+    // logd("Format: %x", bufferDesc.format);
+    // logd("Feature flags: %jx", bufferDesc.usage);
+
     // Get the AHB propertoes
     VkAndroidHardwareBufferFormatPropertiesANDROID formatInfo = {
             .sType =

--- a/app/src/main/cpp/vulkan-utils/VulkanImageRenderer.h
+++ b/app/src/main/cpp/vulkan-utils/VulkanImageRenderer.h
@@ -82,7 +82,7 @@ public:
      *
      * This is the main workhorse of the pipeline that processes each new frame image.
      *
-     * @param new_vkAHB VulkanAHardwareBufferImage ready to be used with the new AImaged
+     * @param vkAHB VulkanAHardwareBufferImage ready to be used with the new AImaged
      * @param filter_params Current filter paramters
      * @param new_aimage New AImage from the ImageReader
      * @param draw_to_screen Is Vulkan allowed to draw to the screen
@@ -92,7 +92,7 @@ public:
      * @param image_copy_data If not null, the frame should be copied into the given, pre-allocated, memory
      * @return Time (in ms) that frame render took. NOTE: this does not work currently
      */
-    double renderImageAndReadback(VulkanAHardwareBufferImage *new_vkAHB,
+    double renderImageAndReadback(VulkanAHardwareBufferImage *vkAHB,
                                   FilterParams *filter_params, AImage *new_aimage,
                                   bool draw_to_screen, bool surface_ready_left, bool surface_ready_right,
                                   RENDERER_RETURN_CODE &render_state,

--- a/app/src/main/cpp/vulkan-utils/VulkanInstance.cpp
+++ b/app/src/main/cpp/vulkan-utils/VulkanInstance.cpp
@@ -96,11 +96,17 @@ bool VulkanInstance::init() {
             .sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,
             .pNext = nullptr,
             .pApplicationInfo = &appInfo,
-            .enabledLayerCount = 0,
-            .ppEnabledLayerNames = nullptr,
             .enabledExtensionCount = static_cast<uint32_t>(instanceExt.size()),
             .ppEnabledExtensionNames = instanceExt.data(),
     };
+    // Enable validation // debugging
+    if (enableValidationLayers) {
+        createInfo.enabledLayerCount = static_cast<uint32_t>(validationLayers.size());
+        createInfo.ppEnabledLayerNames = validationLayers.data();
+    } else {
+        createInfo.enabledLayerCount = 0;
+        createInfo.ppEnabledLayerNames = nullptr;
+    }
     VK_CALL(vkCreateInstance(&createInfo, nullptr, &mInstance));
 
     // Find a GPU to use.
@@ -112,34 +118,16 @@ bool VulkanInstance::init() {
     ASSERT(status == VK_SUCCESS || status == VK_INCOMPLETE);
     ASSERT(gpuCount > 0);
 
-    // Enable validation // debugging
-    if (enableValidationLayers) {
-        createInfo.enabledLayerCount = static_cast<uint32_t>(validationLayers.size());
-        createInfo.ppEnabledLayerNames = validationLayers.data();
-    } else {
-        createInfo.enabledLayerCount = 0;
-        createInfo.ppEnabledLayerNames = nullptr;
-    }
-    VK_CALL(vkCreateInstance(&createInfo, nullptr, &mInstance));
-
     vks::debug::setupDebugging(mInstance, VK_DEBUG_REPORT_ERROR_BIT_EXT | VK_DEBUG_REPORT_WARNING_BIT_EXT | VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT, VK_NULL_HANDLE);
-//    vks::debug::setupDebugging(mInstance, VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT, VK_NULL_HANDLE);
-//    vks::debug::setupDebugging(mInstance, VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT, VK_NULL_HANDLE);
-//    vks::debug::setupDebugging(mInstance, VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT, VK_NULL_HANDLE);
-//    vks::debug::setupDebugging(mInstance, VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT, VK_NULL_HANDLE);
-//    vks::debug::setupDebugging(mInstance, VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT, VK_NULL_HANDLE);
-//    vks::debug::setupDebugging(mInstance, VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT, VK_NULL_HANDLE);
 
     // Setup extensions
     VkPhysicalDeviceProperties physicalDeviceProperties;
     vkGetPhysicalDeviceProperties(mGpu, &physicalDeviceProperties);
     std::vector<const char *> deviceExt;
-    // if (physicalDeviceProperties.apiVersion < VK_API_VERSION_1_1) {
-        deviceExt.push_back(VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME);
-        deviceExt.push_back(VK_KHR_BIND_MEMORY_2_EXTENSION_NAME);
-        deviceExt.push_back(VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME);
-        deviceExt.push_back(VK_KHR_EXTERNAL_SEMAPHORE_EXTENSION_NAME);
-    // }
+    deviceExt.push_back(VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME);
+    deviceExt.push_back(VK_KHR_BIND_MEMORY_2_EXTENSION_NAME);
+    deviceExt.push_back(VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME);
+    deviceExt.push_back(VK_KHR_EXTERNAL_SEMAPHORE_EXTENSION_NAME);
     deviceExt.push_back(VK_KHR_EXTERNAL_SEMAPHORE_FD_EXTENSION_NAME);
     deviceExt.push_back(VK_EXT_QUEUE_FAMILY_FOREIGN_EXTENSION_NAME);
     deviceExt.push_back(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME);

--- a/app/src/main/cpp/vulkan-utils/VulkanInstance.h
+++ b/app/src/main/cpp/vulkan-utils/VulkanInstance.h
@@ -17,7 +17,6 @@
 #ifndef VULKAN_PHOTO_BOOTH_VULKANINSTANCE_H
 #define VULKAN_PHOTO_BOOTH_VULKANINSTANCE_H
 
-
 #include <vulkan/vulkan.h>
 #include <vector>
 
@@ -29,21 +28,7 @@ const bool enableValidationLayers = false;
 #endif
 
 const std::vector<const char*> validationLayers = {
-        // After Vulkan 1.2+ only use this layer, for now select which layers to use
-         "VK_LAYER_KHRONOS_validation"
-
-        // Parameter validation throws a huge number of errors about
-        // VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_ANDROID as this has not yet been added
-        // Uncomment when Vulkan 1.2+ hits or if other code paths are needed
-        // "VK_LAYER_LUNARG_parameter_validation",
-
-        // Core validation is segfaulting. Possibly an include problem, or a code bug
-        // A/libc: Fatal signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x0 in tid 13347 (ImageReader-326), pid 13308 (ulkanphotobooth)
-        // "VK_LAYER_LUNARG_core_validation",
-
-        // "VK_LAYER_GOOGLE_threading",
-        // "VK_LAYER_LUNARG_object_tracker",
-        // "VK_LAYER_GOOGLE_unique_objects",
+        "VK_LAYER_KHRONOS_validation"
 };
 
 class VulkanInstance {

--- a/app/src/main/cpp/vulkan-utils/VulkanSwapchain.cpp
+++ b/app/src/main/cpp/vulkan-utils/VulkanSwapchain.cpp
@@ -88,10 +88,6 @@ VulkanSwapchain::~VulkanSwapchain() {
                 AImage_delete(mSwapchainImages[i].old_aimage);
                 mSwapchainImages[i].old_aimage = nullptr;
             }
-            if (mSwapchainImages[i].old_vkAHB != nullptr) {
-                free(mSwapchainImages[i].old_vkAHB);
-                mSwapchainImages[i].old_vkAHB = nullptr;
-            }
         }
     } // For all swapchains
 }
@@ -375,7 +371,6 @@ bool VulkanSwapchain::init(VkSurfaceKHR *vkSurface, VkSurfaceCapabilitiesKHR *su
 
                 .cmdBuffer = cmdBuffer,
                 .old_aimage = nullptr,
-                .old_vkAHB = nullptr,
         };
     }
 

--- a/app/src/main/cpp/vulkan-utils/VulkanSwapchain.h
+++ b/app/src/main/cpp/vulkan-utils/VulkanSwapchain.h
@@ -49,7 +49,6 @@ struct SwapchainImage {
 
     VkCommandBuffer cmdBuffer;
     AImage *old_aimage;
-    VulkanAHardwareBufferImage *old_vkAHB;
 };
 
 /**

--- a/app/src/main/java/dev/hadrosaur/vulkanphotobooth/LeftPanelActivity.kt
+++ b/app/src/main/java/dev/hadrosaur/vulkanphotobooth/LeftPanelActivity.kt
@@ -33,14 +33,14 @@ class LeftPanelActivity : AppCompatActivity(), SurfaceHolder.Callback {
         }
     }
 
-    override fun surfaceChanged(holder: SurfaceHolder?, format: Int, width: Int, height: Int) {
+    override fun surfaceChanged(holder: SurfaceHolder, format: Int, width: Int, height: Int) {
     }
 
-    override fun surfaceDestroyed(holder: SurfaceHolder?) {
+    override fun surfaceDestroyed(holder: SurfaceHolder) {
         leftSurfaceReady(false)
     }
 
-    override fun surfaceCreated(holder: SurfaceHolder?) {
+    override fun surfaceCreated(holder: SurfaceHolder) {
         leftSurfaceReady(true)
         if (holder?.surface != null)
             setupVulkanSurfaceLeft(holder.surface)

--- a/app/src/main/java/dev/hadrosaur/vulkanphotobooth/MainActivity.kt
+++ b/app/src/main/java/dev/hadrosaur/vulkanphotobooth/MainActivity.kt
@@ -279,7 +279,7 @@ class MainActivity : AppCompatActivity(), SurfaceHolder.Callback {
         // Handler to receive fps messages and send them to the UI
         nativeUpdateFpsHandler = @SuppressLint("HandlerLeak")
         object : Handler() {
-            override fun handleMessage(msg: Message?) {
+            override fun handleMessage(msg: Message) {
                 if (null != msg) {
                     updateFpsText(msg.arg1.toFloat() / 10, msg.arg2)
                 }
@@ -289,7 +289,7 @@ class MainActivity : AppCompatActivity(), SurfaceHolder.Callback {
         // Handler to receive GIF progress messages and send them to the UI
         nativeUpdateGifProgressHandler = @SuppressLint("HandlerLeak")
         object : Handler() {
-            override fun handleMessage(msg: Message?) {
+            override fun handleMessage(msg: Message) {
                 if (null != msg) {
                     val progress = msg.arg1.toFloat() / 100
 
@@ -318,7 +318,7 @@ class MainActivity : AppCompatActivity(), SurfaceHolder.Callback {
         // to encode on this new thread. This way Kotlin handles the thread management
         nativeGifReadyToEncodeHandler = @SuppressLint("HandlerLeak")
         object : Handler() {
-            override fun handleMessage(msg: Message?) {
+            override fun handleMessage(msg: Message) {
                 if (null != msg) {
                     thread(start = true, name = "VulkanEncodeGif") {
                         runOnUiThread {
@@ -510,7 +510,7 @@ class MainActivity : AppCompatActivity(), SurfaceHolder.Callback {
         */
     }
 
-    override fun surfaceChanged(holder: SurfaceHolder?, format: Int, width: Int, height: Int) {
+    override fun surfaceChanged(holder: SurfaceHolder, format: Int, width: Int, height: Int) {
         if (!cameraParams.id.equals("") && checkPermissions()) {
             camera2OpenCamera(this, cameraParams)
         } else {
@@ -521,7 +521,7 @@ class MainActivity : AppCompatActivity(), SurfaceHolder.Callback {
         setNativeDrawToDisplay(true)
     }
 
-    override fun surfaceDestroyed(holder: SurfaceHolder?) {
+    override fun surfaceDestroyed(holder: SurfaceHolder) {
         surfaceReady(false)
 
         // Stop the camera outputting frames to the screen
@@ -535,7 +535,7 @@ class MainActivity : AppCompatActivity(), SurfaceHolder.Callback {
         }
     }
 
-    override fun surfaceCreated(holder: SurfaceHolder?) {
+    override fun surfaceCreated(holder: SurfaceHolder) {
     }
 
     /**

--- a/app/src/main/java/dev/hadrosaur/vulkanphotobooth/RightPanelActivity.kt
+++ b/app/src/main/java/dev/hadrosaur/vulkanphotobooth/RightPanelActivity.kt
@@ -33,17 +33,17 @@ class RightPanelActivity : AppCompatActivity(), SurfaceHolder.Callback {
         }
     }
 
-    override fun surfaceDestroyed(holder: SurfaceHolder?) {
+    override fun surfaceDestroyed(holder: SurfaceHolder) {
         rightSurfaceReady(false)
     }
 
-    override fun surfaceCreated(holder: SurfaceHolder?) {
+    override fun surfaceCreated(holder: SurfaceHolder) {
         rightSurfaceReady(true)
-        if (holder?.surface != null)
+        if (holder.surface != null)
             setupVulkanSurfaceRight(holder.surface)
     }
 
-    override fun surfaceChanged(holder: SurfaceHolder?, format: Int, width: Int, height: Int) {
+    override fun surfaceChanged(holder: SurfaceHolder, format: Int, width: Int, height: Int) {
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/dev/hadrosaur/vulkanphotobooth/cameracontroller/Camera2CaptureCallback.kt
+++ b/app/src/main/java/dev/hadrosaur/vulkanphotobooth/cameracontroller/Camera2CaptureCallback.kt
@@ -29,15 +29,15 @@ class Camera2CaptureCallback(
     internal val params: CameraParams
     ) : CameraCaptureSession.CaptureCallback() {
 
-    override fun onCaptureSequenceAborted(session: CameraCaptureSession?, sequenceId: Int) {
+    override fun onCaptureSequenceAborted(session: CameraCaptureSession, sequenceId: Int) {
         if (session != null)
             super.onCaptureSequenceAborted(session, sequenceId)
     }
 
     override fun onCaptureFailed(
-        session: CameraCaptureSession?,
-        request: CaptureRequest?,
-        failure: CaptureFailure?
+        session: CameraCaptureSession,
+        request: CaptureRequest,
+        failure: CaptureFailure
     ) {
 
         if (!params.isOpen) {
@@ -56,8 +56,8 @@ class Camera2CaptureCallback(
     }
 
     override fun onCaptureStarted(
-        session: CameraCaptureSession?,
-        request: CaptureRequest?,
+        session: CameraCaptureSession,
+        request: CaptureRequest,
         timestamp: Long,
         frameNumber: Long
     ) {
@@ -66,18 +66,18 @@ class Camera2CaptureCallback(
     }
 
     override fun onCaptureProgressed(
-        session: CameraCaptureSession?,
-        request: CaptureRequest?,
-        partialResult: CaptureResult?
+        session: CameraCaptureSession,
+        request: CaptureRequest,
+        partialResult: CaptureResult
     ) {
         if (session != null && request != null && partialResult != null)
             super.onCaptureProgressed(session, request, partialResult)
     }
 
     override fun onCaptureBufferLost(
-        session: CameraCaptureSession?,
-        request: CaptureRequest?,
-        target: Surface?,
+        session: CameraCaptureSession,
+        request: CaptureRequest,
+        target: Surface,
         frameNumber: Long
     ) {
         MainActivity.logd("captureStillPicture captureCallback: Buffer lost")

--- a/app/src/main/java/dev/hadrosaur/vulkanphotobooth/cameracontroller/Camera2CaptureSessionCallback.kt
+++ b/app/src/main/java/dev/hadrosaur/vulkanphotobooth/cameracontroller/Camera2CaptureSessionCallback.kt
@@ -33,25 +33,23 @@ class Camera2CaptureSessionCallback(
 ) : CameraCaptureSession.CaptureCallback() {
 
     override fun onCaptureSequenceCompleted(
-        session: CameraCaptureSession?,
+        session: CameraCaptureSession,
         sequenceId: Int,
         frameNumber: Long
     ) {
-        if (session != null)
-            super.onCaptureSequenceCompleted(session, sequenceId, frameNumber)
+        super.onCaptureSequenceCompleted(session, sequenceId, frameNumber)
     }
 
-    override fun onCaptureSequenceAborted(session: CameraCaptureSession?, sequenceId: Int) {
+    override fun onCaptureSequenceAborted(session: CameraCaptureSession, sequenceId: Int) {
         MainActivity.logd("Camera2CaptureSessionCallback : Capture sequence ABORTED")
 
-        if (session != null)
-            super.onCaptureSequenceAborted(session, sequenceId)
+        super.onCaptureSequenceAborted(session, sequenceId)
     }
 
     override fun onCaptureFailed(
-        session: CameraCaptureSession?,
-        request: CaptureRequest?,
-        failure: CaptureFailure?
+        session: CameraCaptureSession,
+        request: CaptureRequest,
+        failure: CaptureFailure
     ) {
         MainActivity.logd("Camera2CaptureSessionCallback : Capture sequence FAILED - " +
             failure?.reason)

--- a/app/src/main/java/dev/hadrosaur/vulkanphotobooth/cameracontroller/Camera2Controller.kt
+++ b/app/src/main/java/dev/hadrosaur/vulkanphotobooth/cameracontroller/Camera2Controller.kt
@@ -123,7 +123,7 @@ fun camera2StartPreview(activity: MainActivity, params: CameraParams) {
 //        params.captureRequestBuilder =
 //            params.device?.createCaptureRequest(CameraDevice.TEMPLATE_STILL_CAPTURE)
 
-        params.captureRequestBuilder?.addTarget(params.previewImageReaderSurface)
+        params.captureRequestBuilder?.addTarget(params.previewImageReaderSurface!!)
 
         logd("In camera2StartPreview. Added request.")
         logd("Preview SurfaceView width: " + params.previewSurfaceView?.width + ", height: " + params.previewSurfaceView?.height)

--- a/app/src/main/java/dev/hadrosaur/vulkanphotobooth/cameracontroller/Camera2DeviceStateCallback.kt
+++ b/app/src/main/java/dev/hadrosaur/vulkanphotobooth/cameracontroller/Camera2DeviceStateCallback.kt
@@ -44,7 +44,7 @@ class Camera2DeviceStateCallback(
     /**
      * Camera device has been closed.
      */
-    override fun onClosed(camera: CameraDevice?) {
+    override fun onClosed(camera: CameraDevice) {
 
         params.isOpen = false
         params.isClosing = false;

--- a/app/src/main/java/dev/hadrosaur/vulkanphotobooth/cameracontroller/Camera2PreviewSessionStateCallback.kt
+++ b/app/src/main/java/dev/hadrosaur/vulkanphotobooth/cameracontroller/Camera2PreviewSessionStateCallback.kt
@@ -34,7 +34,7 @@ class Camera2PreviewSessionStateCallback(
 ) : CameraCaptureSession.StateCallback() {
 
     // Preview session is open and frames are coming through.
-    override fun onActive(session: CameraCaptureSession?) {
+    override fun onActive(session: CameraCaptureSession) {
         if (!params.isOpen || params.state != CameraState.PREVIEW_RUNNING) {
             return
         }
@@ -44,8 +44,7 @@ class Camera2PreviewSessionStateCallback(
 
         // initializeStillCapture(activity, params, testConfig)
 
-        if (session != null)
-            super.onActive(session)
+        super.onActive(session)
     }
 
     /**

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.0-rc01'
+        classpath 'com.android.tools.build:gradle:7.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 //        classpath 'com.google.gms:google-services:4.3.3'
     }


### PR DESCRIPTION
Now only create VulkanAndroidHardwareBuffer's for each AHB once and keep
references to them in a hashmap rather than create an initialize an AHB
every frame.

Also upgraded to gradle 7.0.0 and removed some unnecessary null checks.