### PR TITLE
Fix resizing crash due to camera close timing

### DIFF
--- a/app/src/main/cpp/ImageReaderListener.h
+++ b/app/src/main/cpp/ImageReaderListener.h
@@ -44,8 +44,7 @@ public:
     RingBuffer<uint32_t *> *gifRingBuffer;
     static int gif_frames_captured; // Counter for # frames captured for GIF so far
 
-    ImageReaderListener(VulkanInstance *instance, VulkanImageRenderer *renderer, FilterParams *filterParams, ANativeWindow *outputWindow);
-    VulkanAHBManager vahb_manager;
+    ImageReaderListener(VulkanInstance *instance, VulkanImageRenderer *renderer, VulkanAHBManager *vahbManager, FilterParams *filterParams, ANativeWindow *outputWindow);
 
     static void onImageAvailableCallback(void* obj, AImageReader* reader);
     void onImageAvailable(void* obj, AImageReader* reader);
@@ -55,6 +54,7 @@ private:
     VulkanInstance *mInstance = nullptr;
     VulkanImageRenderer *mRenderer = nullptr;
     FilterParams *mFilterParams = nullptr;
+    VulkanAHBManager *mVahbManager = nullptr;
     ANativeWindow *mMainOutputWindow = nullptr; // The output surface to grab images from for gif
     int mOnImageAvailableCount = 0;
 

--- a/app/src/main/cpp/native-lib.cpp
+++ b/app/src/main/cpp/native-lib.cpp
@@ -59,11 +59,12 @@ uint32_t NUM_DISPLAYS = 0;
 // Vulkan globals
 VulkanInstance *vulkan_instance = nullptr;
 VulkanImageRenderer *renderer = nullptr;
+VulkanAHBManager *vahbManager = nullptr;
 
 // Current set of filter paramters
 FilterParams *filter_params = nullptr;
 
-GCTGifEncoder* gifEncoder = nullptr;
+GCTGifEncoder *gifEncoder = nullptr;
 //FastGifEncoder* gifEncoder = nullptr;
 
 // Default GIF width/height
@@ -113,6 +114,10 @@ bool InitializeVulkan() {
         return false;
     }
 
+    // Create AHB manager
+    vahbManager = new VulkanAHBManager();
+    vahbManager->setVulkanInstance(vulkan_instance);
+
     ImageReaderListener::native_draw_to_display = true;
     return true;
 }
@@ -144,7 +149,7 @@ void areSurfacesReady() {
 //    ASSERT_FORMATTED(renderer->init(output_window, output_window, output_window), "Could not init VulkanImageRenderer.");
 
     // Set up ImageReader
-    listener = new ImageReaderListener(vulkan_instance, renderer, filter_params, output_window);
+    listener = new ImageReaderListener(vulkan_instance, renderer, vahbManager, filter_params, output_window);
     AImageReader_ImageListener preview_image_listener { listener, ImageReaderListener::onImageAvailableCallback };
     AImageReader_setImageListener(preview_reader, &preview_image_listener);
 }
@@ -157,6 +162,7 @@ void cleanup() {
     if (nullptr != renderer)
         delete(renderer);
 
+    delete(vahbManager);
     delete(vulkan_instance);
     delete(filter_params);
     delete(listener);

--- a/app/src/main/cpp/vulkan-utils/VulkanAHBManager.cpp
+++ b/app/src/main/cpp/vulkan-utils/VulkanAHBManager.cpp
@@ -18,9 +18,9 @@
 #include "vulkan_utils.h"
 
 VulkanAHBManager::~VulkanAHBManager() {
-    // Call destructor for all the created VulkanAHardwareBufferImages
+    // Delete all the created VulkanAHardwareBufferImages
     for (auto item : ahb_map) {
-        item.second->~VulkanAHardwareBufferImage();
+        delete item.second;
     }
 }
 

--- a/app/src/main/cpp/vulkan-utils/VulkanImageRenderer.cpp
+++ b/app/src/main/cpp/vulkan-utils/VulkanImageRenderer.cpp
@@ -135,7 +135,6 @@ bool VulkanImageRenderer::init(ANativeWindow *output_window, ANativeWindow *outp
 
     // Create the output surfaces
     {
-
         uint32_t queue_family_count;
         vkGetPhysicalDeviceQueueFamilyProperties(mInstance->gpu(), &queue_family_count,
                                                  NULL);

--- a/app/src/main/java/dev/hadrosaur/vulkanphotobooth/MainActivity.kt
+++ b/app/src/main/java/dev/hadrosaur/vulkanphotobooth/MainActivity.kt
@@ -435,7 +435,7 @@ class MainActivity : AppCompatActivity(), SurfaceHolder.Callback {
             midiManager = getSystemService(Context.MIDI_SERVICE) as MidiManager
             initializeMidiControls(this)
         } else {
-            logd("This device does not support MIDI.")
+            // logd("This device does not support MIDI.")
         }
 
         // Setup on-screen UI
@@ -880,12 +880,12 @@ class MainActivity : AppCompatActivity(), SurfaceHolder.Callback {
         if (!hasMidi) return
 
         val midiDeviceInfos = midiManager.devices
-        logd("MIDI: Number of connected devices: " + midiDeviceInfos.size)
+        // logd("MIDI: Number of connected devices: " + midiDeviceInfos.size)
         for (info: MidiDeviceInfo in midiDeviceInfos) {
-            logd("A MIDI device is plugged in: " + info.id + ", output ports: " + info.outputPortCount)
+            // logd("A MIDI device is plugged in: " + info.id + ", output ports: " + info.outputPortCount)
             val props: Bundle = info.getProperties()
-            logd("Props for " + info.id + ": manufacturer: " + props.getString(MidiDeviceInfo.PROPERTY_MANUFACTURER) +
-                    ", product: " + props.getString(MidiDeviceInfo.PROPERTY_PRODUCT))
+            // logd("Props for " + info.id + ": manufacturer: " + props.getString(MidiDeviceInfo.PROPERTY_MANUFACTURER) +
+            //        ", product: " + props.getString(MidiDeviceInfo.PROPERTY_PRODUCT))
 
             // Use the last device with midi signals
             // TODO: This assumes Android registers external midi devices as the last device.
@@ -900,10 +900,10 @@ class MainActivity : AppCompatActivity(), SurfaceHolder.Callback {
             override fun onDeviceAdded(info: MidiDeviceInfo?) {
                 if (null == info) { return }
 
-                logd("A MIDI device has been connected: " + info.id + ", output ports: " + info.outputPortCount)
+                // logd("A MIDI device has been connected: " + info.id + ", output ports: " + info.outputPortCount)
                 val props: Bundle = info.getProperties()
-                logd("Props for " + info.id + ": manufacturer: " + props.getString(MidiDeviceInfo.PROPERTY_MANUFACTURER) +
-                        ", product: " + props.getString(MidiDeviceInfo.PROPERTY_PRODUCT))
+                // logd("Props for " + info.id + ": manufacturer: " + props.getString(MidiDeviceInfo.PROPERTY_MANUFACTURER) +
+                //        ", product: " + props.getString(MidiDeviceInfo.PROPERTY_PRODUCT))
 
                 // If a new device is connected, and it has ports, connect it to the sliders
                 if (info.outputPortCount > 0) {
@@ -912,7 +912,7 @@ class MainActivity : AppCompatActivity(), SurfaceHolder.Callback {
             }
 
             override fun onDeviceRemoved(info: MidiDeviceInfo?) {
-                logd("A MIDI device has been removed: " + info?.id + ", output ports: " + info?.outputPortCount)
+                // logd("A MIDI device has been removed: " + info?.id + ", output ports: " + info?.outputPortCount)
 
                 if (vulkanViewModel.currentMidiDevice >= 0
                     && info != null) {
@@ -925,27 +925,27 @@ class MainActivity : AppCompatActivity(), SurfaceHolder.Callback {
     }
 
     fun connectMidiDeviceToSliders(activity: MainActivity, info: MidiDeviceInfo) {
-        logd("MIDI: In connectMidiDeviceToSliders")
+        // logd("MIDI: In connectMidiDeviceToSliders")
         if (vulkanViewModel.currentMidiDevice >= 0
             && vulkanViewModel.currentMidiDevice != info.id) {
             disconnectMidiDeviceFromSliders(info)
         }
 
         // Open the device
-        logd("MIDI: proceeding to open MIDI device")
+        // logd("MIDI: proceeding to open MIDI device")
         midiManager.openDevice(info, object: MidiManager.OnDeviceOpenedListener {
             override fun onDeviceOpened(device: MidiDevice?) {
-                logd("MIDI: device opened.")
+                // logd("MIDI: device opened.")
                 vulkanViewModel.currentOpenMidiDevice = device
 
                 if (null != device) {
                     vulkanViewModel.currentMidiDevice = info.id
                     val portIndex = getFirstMidiOutputPortIndex(info)
-                    logd("MIDI: First output port index: " + portIndex)
+                    // logd("MIDI: First output port index: " + portIndex)
                     if (portIndex != -1) {
-                        logd("MIDI: opening output port")
+                        // logd("MIDI: opening output port")
                         val outputPort: MidiOutputPort = device.openOutputPort(portIndex)
-                        logd("MIDI: connecting slider receiver!")
+                        // logd("MIDI: connecting slider receiver!")
                         outputPort.onConnect(MidiSliderReceiver(activity));
                     }
                 }
@@ -1010,7 +1010,7 @@ class MainActivity : AppCompatActivity(), SurfaceHolder.Callback {
     class MidiSliderReceiver(val activity: MainActivity): MidiReceiver() {
         override fun onSend(msg: ByteArray?, offset: Int, count: Int, timestamp: Long) {
             if (null == msg) {
-                logd("NULL MIDI message received")
+                // logd("NULL MIDI message received")
             } else {
 
 //                logd("Received a MIDI message.")
@@ -1032,13 +1032,13 @@ class MainActivity : AppCompatActivity(), SurfaceHolder.Callback {
                     if ((currentInt and 0b10000000) != 0){
 
                         if (currentInt == 0b11110000) {
-                            logd("System message start, let's ignore it...")
+                            // logd("System message start, let's ignore it...")
                             systemMessage = true
                             i++
                             continue
                         }
                         if (currentInt == 0b11110111) {
-                            logd("System message end.")
+                            // logd("System message end.")
                             systemMessage = false
                             i++
                             continue
@@ -1101,13 +1101,13 @@ class MainActivity : AppCompatActivity(), SurfaceHolder.Callback {
                                 MIDI_ID_AKAI_BUTTON -> {
                                     if (levelInt == MIDI_ID_AKAI_BUTTON_ON_VALUE) {
                                         activity.runOnUiThread {
-                                            logd("MIDI BUTTON CLICK")
+                                           // logd("MIDI BUTTON CLICK")
 //                                            activity.button_shutter.callOnClick()
                                         }
                                     }
                                 }
                                else -> {
-                                    logd("Midi controller: " + controllerIdInt + " ajusted to value: " + levelInt)
+                                    // logd("Midi controller: " + controllerIdInt + " ajusted to value: " + levelInt)
                                 }
                             }
                         } else {
@@ -1147,7 +1147,7 @@ class MainActivity : AppCompatActivity(), SurfaceHolder.Callback {
                                     }
                                 }
                                 else -> {
-                                    logd("Midi controller: " + controllerIdInt + " ajusted to value: " + levelInt)
+                                    // logd("Midi controller: " + controllerIdInt + " ajusted to value: " + levelInt)
                                 }
 
                             }

--- a/app/src/main/java/dev/hadrosaur/vulkanphotobooth/cameracontroller/Camera2DeviceStateCallback.kt
+++ b/app/src/main/java/dev/hadrosaur/vulkanphotobooth/cameracontroller/Camera2DeviceStateCallback.kt
@@ -45,6 +45,7 @@ class Camera2DeviceStateCallback(
      * Camera device has been closed.
      */
     override fun onClosed(camera: CameraDevice) {
+        // logd("Camera has been closed correctly.")
 
         params.isOpen = false
         params.isClosing = false;


### PR DESCRIPTION
Sometimes the camera would not close fast enough on resize events, when
opening the camera after the surface was re-created, it could get stuck
in an endless loop due to a sleep call. This removes that call and uses
postDelayed to not block the camera thread.

Also clean up a memory leak with AHBManager calling the destructor
instead of delete for it's members.

Also, moved AHBManger logic out of ImageReaderListener to ensure that it
is created after VulkanInstance creation and destroyed at the right
time.